### PR TITLE
chore: parametrize vLLM settings

### DIFF
--- a/agent-morpheus-models/charts/llama3_1_70b_instruct_4bit/templates/deployment.yaml
+++ b/agent-morpheus-models/charts/llama3_1_70b_instruct_4bit/templates/deployment.yaml
@@ -35,7 +35,15 @@ spec:
         - name: {{ .Chart.Name | replace "_" "-" }}
           workingDir: /vllm-workspace
           command: [ "python3" , "-m" , "vllm.entrypoints.openai.api_server" ]
-          args: [ "--model", "hugging-quants/Meta-Llama-3.1-70B-Instruct-AWQ-INT4","--tensor-parallel-size", "2", "--max-model-len", "8192", "--max_num_seqs", "128" ]
+          args:
+          - "--model"
+          - "{{ .Values.model.name }}"
+          - "--tensor-parallel-size"
+          - "{{ .Values.vllm.tensor_parallel_size }}"
+          - "--max-model-len"
+          - "{{ .Values.vllm.max_model_len }}"
+          - "--max-num-seqs"
+          - "{{ .Values.vllm.max_num_seqs }}"
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/agent-morpheus-models/charts/llama3_1_70b_instruct_4bit/values.yaml
+++ b/agent-morpheus-models/charts/llama3_1_70b_instruct_4bit/values.yaml
@@ -10,6 +10,14 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
 
+model:
+  name: hugging-quants/Meta-Llama-3.1-70B-Instruct-AWQ-INT4
+
+vllm:
+  tensor_parallel_size: 4
+  max_model_len: 8192
+  max_num_seqs: 32
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
The following values are now configurable

- `model.name`: Path to the model repository.
- `vllm.tensor_parallel_size`: Number of tensor parallel replicas.
- `vllm.max_model_len`: Model context length.
- `vllm.max_num_seqs`: Maximum number of sequences per iteration.