### PR TITLE
downgrade vLLM to 0.6.6.post1, adjust tensor_parallel and CPU limits

### DIFF
--- a/agent-morpheus-models/charts/llama3_1_70b_instruct_4bit/values.yaml
+++ b/agent-morpheus-models/charts/llama3_1_70b_instruct_4bit/values.yaml
@@ -8,13 +8,13 @@ image:
   repository: docker.io/vllm/vllm-openai
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.8.4"
+  tag: "v0.6.6.post1"
 
 model:
   name: hugging-quants/Meta-Llama-3.1-70B-Instruct-AWQ-INT4
 
 vllm:
-  tensor_parallel_size: 4
+  tensor_parallel_size: 2
   max_model_len: 8192
   max_num_seqs: 32
 
@@ -75,7 +75,7 @@ ingress:
 
 resources:
   limits:
-    cpu: 1000m
+    cpu: 2000m
     memory: 35Gi
     nvidia.com/gpu: "2"
   requests:


### PR DESCRIPTION
- Downgraded vLLM to `0.6.6.post1` due to performance issues in `0.8.5.post1`
- Set `tensor_parallel_size=2` since 4 caused instability. 
- Increased CPU limit to 2000m to prevent throttling under load.
